### PR TITLE
Multiples fixes : Multiple languages have some missing language keys + Cosmetic

### DIFF
--- a/Controller/Trader.php
+++ b/Controller/Trader.php
@@ -99,8 +99,8 @@ class Trader
         $feedback_reply_id = $this->request->variable('reply_id', 0);
 
         $rating = $this->request->variable('trader_rating', 0);
-        $short_comment = trim($this->request->variable('short_comment', ''));
-        $long_comment = trim($this->request->variable('long_comment', ''));
+        $short_comment = utf8_normalize_nfc(trim($this->request->variable('short_comment', '', true)));
+        $long_comment = utf8_normalize_nfc(trim($this->request->variable('long_comment', '', true)));
 
         if ($feedback_reply_id) {
             $feedback_row = $this->manager->getAllFeedbackInfo($feedback_reply_id);
@@ -117,7 +117,7 @@ class Trader
             'u' => $user_id,
         ));
 
-        $back_url = '<a href=' . append_sid(generate_board_url() . "/viewtopic.php?t=" . $topic_id) . '>Back</a>';
+        $back_url = '<a href=' . append_sid(generate_board_url() . "/viewtopic.php?t=" . $topic_id) . '>&laquo; ' . ($this->user->lang['BACK_TO_PREV']) . '</a>';
 
         $submit = $this->request->is_set_post('submit');
 
@@ -169,7 +169,7 @@ class Trader
 
             $trader_profile_url = '<a href=' . $this->helper->route('rfd_trader_view', array(
                     'u' => $to_user_row['user_id'],
-                )) . '>View Profile</a>';
+                )) . '>' . ($this->user->lang['VIEW_PROFILE']) . '&nbsp;' . $to_user_row['username'] . '</a>';
             trigger_error($this->user->lang('FEEDBACK_SUCCESS') . '<br /><br />' . $trader_profile_url);
         }
 
@@ -186,7 +186,7 @@ class Trader
             'U_TRADER_FEEDBACK' => $feedback_route,
             'U_TRADER_PROFILE' => append_sid("{$this->phpbb_root_path}memberlist.$this->phpEx", 'mode=viewprofile&amp;u=' . $to_user_row['user_id']),
         ));
-        return $this->helper->render('TraderFeedback.html', 'Give Feedback');
+        return $this->helper->render('TraderFeedback.html', ($this->user->lang['FEEDBACK_TITLE']) . $to_user_row['username']);
     }
 
     public function editFeedbackAction()
@@ -203,7 +203,7 @@ class Trader
         $feedback_route = $this->helper->route('rfd_trader_view', array(
             'u' => $return_user_id,
         ));
-        $trader_profile_url = $trader_profile_url = '<a href=' . $feedback_route . '>Back</a>';
+        $trader_profile_url = $trader_profile_url = '<a href=' . $feedback_route . '>' . ($this->user->lang['BACK_TO_PREV']) . '</a>';
 
         if (!$this->canEditFeedback($feedback_row['date_created'], $feedback_row['from_user_id'])) {
             trigger_error($this->user->lang('E_CANNOT_EDIT') . '<br /><br />' . $trader_profile_url);
@@ -215,12 +215,12 @@ class Trader
         $submit = $this->request->is_set_post('submit');
         $to_user_row = $this->getUser($feedback_row['to_user_id']);
         $rating = $this->request->variable('trader_rating', $feedback_row['rating']);
-        $new_short = trim($this->request->variable('short_comment', $feedback_row['short_comment']));
-        $new_long = trim($this->request->variable('long_comment', $feedback_row['long_comment']));
+        $new_short = utf8_normalize_nfc(trim($this->request->variable('short_comment', $feedback_row['short_comment'], true)));
+        $new_long = utf8_normalize_nfc(trim($this->request->variable('long_comment', $feedback_row['long_comment'], true)));
         $delete_feedback = $this->request->variable('delete_feedback', $feedback_row['is_deleted']);
 
         if ($submit && (strlen($new_short) < self::MIN_SHORT_LENGTH || strlen($new_short) > self::MAX_SHORT_LENGTH)) {
-            $err_comments['short'] = '* Required 10-200 Characters';
+            $err_comments['short'] = ($this->user->lang['REQUIERED_CHARACTERS']);
         }
         if ($submit && strlen($new_long) > self::MAX_LONG_LENGTH) {
             $err_comments['long'] = true;
@@ -275,7 +275,7 @@ class Trader
             'U_DATE_FORMAT' => $this->user->data['user_dateformat']
         ));
 
-        return $this->helper->render('TraderFeedback.html', 'Edit Feedback');
+        return $this->helper->render('TraderFeedback.html', ($this->user->lang['FEEDBACK_TITLE_EDIT']) . $to_user_row['username']);
     }
 
     public function viewUserFeedbackAction()
@@ -427,7 +427,7 @@ class Trader
             trigger_error("Unknown Action!");
         }
 
-        return $this->helper->render('view_user_feedback.html', 'Viewing Trader Feedback - User ' . $user_page_row['username']);
+        return $this->helper->render('view_user_feedback.html', ($this->user->lang['TRADER_FEEDBACK_FOR']) . '&nbsp;' . $user_page_row['username']);
     }
 
 

--- a/Controller/Trader.php
+++ b/Controller/Trader.php
@@ -220,7 +220,7 @@ class Trader
         $delete_feedback = $this->request->variable('delete_feedback', $feedback_row['is_deleted']);
 
         if ($submit && (strlen($new_short) < self::MIN_SHORT_LENGTH || strlen($new_short) > self::MAX_SHORT_LENGTH)) {
-            $err_comments['short'] = ($this->user->lang['REQUIERED_CHARACTERS']);
+            $err_comments['short'] = ($this->user->lang['REQUIRED_CHARACTERS']);
         }
         if ($submit && strlen($new_long) > self::MAX_LONG_LENGTH) {
             $err_comments['long'] = true;

--- a/Event/TraderListener.php
+++ b/Event/TraderListener.php
@@ -226,7 +226,7 @@ class TraderListener implements EventSubscriberInterface {
         $data['post_row']['user_trader_negative'] = $negative;
         $data['post_row']['user_trader_percentage'] = $this->manager->getPositivePercent($positive, $negative);
         $data['post_row']['user_trader_rating'] = $positive - $negative;
-        $data['post_row']['title'] = "$positive Positive\n$neutral Neutral\n$negative Negative";
+        $data['post_row']['title'] = "$positive " . ($this->user->lang['POSITIVE']) . "\n$neutral " . ($this->user->lang['NEUTRAL']) . "\n$negative " . ($this->user->lang['NEGATIVE']) . "";
         $event->set_data($data);
     }
 

--- a/styles/all/template/event/navbar_header_profile_list_after.html
+++ b/styles/all/template/event/navbar_header_profile_list_after.html
@@ -1,1 +1,1 @@
-<li class="small-icon icon-members"><a href="{{ U_USER_PROFILE|replace({ ('/memberlist.php?mode=viewprofile&amp;u='): '/trader/view-feedback/?u=' }) }}" title="{L_TRADER_FEEDBACK}" role="menuitem">{L_TRADER_FEEDBACK}</a></li>
+<li class="small-icon icon-members"><a href="{{ U_USER_PROFILE|replace({ ('./memberlist.php?mode=viewprofile&amp;u='): './app.php/trader/view-feedback/?u=' }) }}" title="{L_TRADER_FEEDBACK}" role="menuitem">{L_TRADER_FEEDBACK}</a></li>

--- a/styles/all/template/event/overall_header_breadcrumb_append.html
+++ b/styles/all/template/event/overall_header_breadcrumb_append.html
@@ -1,6 +1,6 @@
 {% if TRADER_USERNAME %}
-    <span class="crumb"><a href="{{ U_TRADER_PROFILE }}" {$MICRODATA} data-navbar-reference="user_profile">{{ TRADER_USERNAME }} {L_READ_PROFILE}</a></span>
+    <span class="crumb"><a href="{{ U_TRADER_PROFILE }}" {$MICRODATA} data-navbar-reference="user_profile">{L_READ_PROFILE} {{ TRADER_USERNAME }}</a></span>
 {% endif %}
 {% if U_TRADER_FEEDBACK %}
-    <span class="crumb"><a href="{{ U_TRADER_FEEDBACK }}">{L_FEEDBACK_PAGE}</a></span>
+    <span class="crumb"><a href="{{ U_TRADER_FEEDBACK }}">{L_FEEDBACK_PAGE} {{ TRADER_USERNAME }}</a></span>
 {% endif %}

--- a/styles/all/template/event/viewtopic_topic_title_prepend.html
+++ b/styles/all/template/event/viewtopic_topic_title_prepend.html
@@ -1,7 +1,7 @@
 {% if TOPIC_TRADER_TYPE == 1 %}
-    <span title="Want to Buy">{L_TOPIC_PREFIX_WANT_TO_BUY}</span>
+    <span title="{L_TO_BUY}">{L_TOPIC_PREFIX_WANT_TO_BUY}</span>
 {% elseif TOPIC_TRADER_TYPE == 2 %}
-    <span title="For Sale">{L_TOPIC_PREFIX_FOR_SALE}</span>
+    <span title="{L_FOR_SALE}">{L_TOPIC_PREFIX_FOR_SALE}</span>
 {% elseif TOPIC_TRADER_TYPE == 4 %}
-    <span title="Want to Trade">{L_TOPIC_PREFIX_WANT_TO_TRADE}</span>
+    <span title="{L_TO_TRADE}">{L_TOPIC_PREFIX_WANT_TO_TRADE}</span>
 {% endif %}

--- a/styles/prosilver/template/TraderFeedback.html
+++ b/styles/prosilver/template/TraderFeedback.html
@@ -6,7 +6,7 @@
                 <h2>  {% if EDIT %} {L_FEEDBACK_TITLE_EDIT} {% else %} {L_FEEDBACK_TITLE} {% endif %} {{ USERNAME }}
                 </h2>
                 <fieldset>
-                    <h3>TOPIC: {% if TOPIC_TYPE==1 %} {L_TOPIC_PREFIX_WANT_TO_BUY} {% elseif TOPIC_TYPE==2 %} {L_TOPIC_PREFIX_FOR_SALE} {% elseif TOPIC_TYPE==3 %} {L_TOPIC_PREFIX_WANT_TO_TRADE} {% endif %}
+                    <h3>{L_TOPIC}{L_COLON} {% if TOPIC_TYPE==1 %} {L_TOPIC_PREFIX_WANT_TO_BUY} {% elseif TOPIC_TYPE==2 %} {L_TOPIC_PREFIX_FOR_SALE} {% elseif TOPIC_TYPE==3 %} {L_TOPIC_PREFIX_WANT_TO_TRADE} {% endif %}
                         {{ TOPIC_TITLE }}
                         </h3>
 
@@ -52,17 +52,17 @@
                     {% if EDIT %}
                         <dl>
                             <dt>
-                                <label for="delete_feedback_yes">Delete Feedback?</label>
+                                <label for="delete_feedback_yes">{L_DELETE_FEEDBACK_Q}</label>
                             </dt>
                             <dd>
                                 <input id="delete_feedback_yes" type="radio" value=1 name="delete_feedback" {% if DELETED %} checked="checked" {% endif %}>
                                 <label for="delete_feedback_yes">
-                                    Yes
+                                    {L_YES}
                                 </label>
 
                                 <input id="delete_feedback_no" type="radio"  value=0 name="delete_feedback" {% if !DELETED %} checked="checked" {% endif %}>
                                 <label for="delete_feedback_no">
-                                    No
+                                    {L_NO}
                                 </label>
                             </dd>
                         </dl>
@@ -76,7 +76,7 @@
     </div>
 </div>
 {% if EDIT && MODERATOR %}
-    <h3>Edit History</h3>
+    <h3>{L_EDIT_HISTORY}</h3>
     {% for revision in HISTORY %}
         <div class="page-body panel bg3">
             <h3>{{ revision.date_created|date(U_DATE_FORMAT, false) }} - {% if revision.username %} {{ revision.username }} {% else %} {L_ORIGINAL_COMMENT} {% endif %}</h3>

--- a/styles/prosilver/template/event/topiclist_row_prepend.html
+++ b/styles/prosilver/template/event/topiclist_row_prepend.html
@@ -1,7 +1,7 @@
 {% if topicrow.TRADER_TYPE == 1 %}
-    <strong title="Want to Buy">{L_TOPIC_PREFIX_WANT_TO_BUY}</strong>
+    <strong title="{L_TO_BUY}">{L_TOPIC_PREFIX_WANT_TO_BUY}</strong>
 {% elseif topicrow.TRADER_TYPE == 2 %}
-    <strong title="For Sale">{L_TOPIC_PREFIX_FOR_SALE}</strong>
+    <strong title="{L_FOR_SALE}">{L_TOPIC_PREFIX_FOR_SALE}</strong>
 {% elseif topicrow.TRADER_TYPE == 4 %}
-    <strong title="Want to Trade">{L_TOPIC_PREFIX_WANT_TO_TRADE}</strong>
+    <strong title="{L_TO_TRADE}">{L_TOPIC_PREFIX_WANT_TO_TRADE}</strong>
 {% endif %}

--- a/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_after.html
@@ -1,5 +1,5 @@
 {% if postrow.user_trader_rating is defined %}
-<dd title="{{ postrow.title }}" class="post_row_feedback_rating">
+<dd title="{{ postrow.title }}"  class="profile-posts">
     <strong>
         {L_TRADER_SCORE}{L_COLON}
     </strong>

--- a/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_after.html
+++ b/styles/prosilver/template/event/viewtopic_body_postrow_custom_fields_after.html
@@ -1,5 +1,5 @@
 {% if postrow.user_trader_rating is defined %}
-<dd title="{{ postrow.title }}"  class="profile-posts">
+<dd title="{{ postrow.title }}" class="profile-posts">
     <strong>
         {L_TRADER_SCORE}{L_COLON}
     </strong>

--- a/styles/prosilver/template/includes/view_trader_feedback_sidebar.html
+++ b/styles/prosilver/template/includes/view_trader_feedback_sidebar.html
@@ -16,11 +16,11 @@
                         </tr>
 
                         {# <tr>
-                            <td>{MEMBRES_WHO_LEFT_POSITIVE}{L_COLON}</td>
+                            <td>{MEMBERS_WHO_LEFT_POSITIVE}{L_COLON}</td>
                             <td>{{ trader_stats.user_trader_positive }}</td>
                         </tr>
                         <tr>
-                            <td>{MEMBRES_WHO_LEFT_NEGATIVE}{L_COLON}</td>
+                            <td>{MEMBERS_WHO_LEFT_NEGATIVE}{L_COLON}</td>
                             <td>{{ trader_stats.user_trader_negative }}</td>
                         </tr> #}
                         <tr>

--- a/styles/prosilver/template/includes/view_trader_feedback_sidebar.html
+++ b/styles/prosilver/template/includes/view_trader_feedback_sidebar.html
@@ -7,20 +7,20 @@
                     <table id="trader_summary">
                         <tbody>
                         <tr>
-                            <td>{L_TRADER_SCORE}:</td>
+                            <td>{L_TRADER_SCORE}{L_COLON}</td>
                             <td><strong>{{ trader_stats.user_trader_rating }}</strong></td>
                         </tr>
                         <tr>
-                            <td>{L_POSITIVE_FEEDBACK}:</td>
+                            <td>{L_POSITIVE_FEEDBACK}{L_COLON}</td>
                             <td>{{ trader_stats.user_trader_percentage }}%</td>
                         </tr>
 
                         {# <tr>
-                            <td>Members who left positive:</td>
+                            <td>{MEMBRES_WHO_LEFT_POSITIVE}{L_COLON}</td>
                             <td>{{ trader_stats.user_trader_positive }}</td>
                         </tr>
                         <tr>
-                            <td>Members who left negative:</td>
+                            <td>{MEMBRES_WHO_LEFT_NEGATIVE}{L_COLON}</td>
                             <td>{{ trader_stats.user_trader_negative }}</td>
                         </tr> #}
                         <tr>

--- a/styles/prosilver/template/report_feedback_form.html
+++ b/styles/prosilver/template/report_feedback_form.html
@@ -7,7 +7,6 @@
     </div>
     <fieldset class="submit-buttons">
         <input type="button" name="confirm" value="{L_SUBMIT}" class="button1" />&nbsp;
-        <input type="submit" name="cancel" value="{L_CANCEL}" class="button2" />
+        <input type="button" name="cancel" value="{L_CANCEL}" class="button2" />
     </fieldset>
 </form>
-

--- a/styles/prosilver/template/view_user_feedback.html
+++ b/styles/prosilver/template/view_user_feedback.html
@@ -35,7 +35,7 @@
                                 <th class="name">{L_FEEDBACK_TYPE}</th>
                                 {% endif %}
                                 <th class="name">{% if CURRENT_TAB == 'left' %}{L_RECIPIENT}{% else %}{L_FROM}{% endif %}</th>
-                                <th class="name">{L_DATE}</th>
+                                <th class="name">{L_TIME}</th>
                                 <th class="name">{L_OPTIONS}</th>
                             </tr>
                             </thead>
@@ -57,7 +57,7 @@
                                         <span class="trader_short_comment">{{ fdb_row.short_comment }}</span>
                                     </td>
                                     <td>
-                                        <a title="Go to Topic: {{ fdb_row.topic_title }}" href="{{ fdb_row.topic_url }}">{{ fdb_row.topic_title }}</a>
+                                        <a title="{L_GO_TO_TOPIC}{L_COLON} {{ fdb_row.topic_title }}" href="{{ fdb_row.topic_url }}">{{ fdb_row.topic_title }}</a>
                                     </td>
                                     {% if CURRENT_TAB == 'left' or CURRENT_TAB == 'all' %}
                                     <td>


### PR DESCRIPTION
- Multiple languages have some missing language keys presents in core files
- Due to accented characters, little patch so that the correct value of
« $short_comment » & « $long_comment » gets stored into the database.
- Cosmetic fixe on viewtopic: No bold text on URL for {{ postrow.U_VIEW_FEEDBACK }}
- Cancel button doesn't work on report page
- Fixed replacement path: https://github.com/rfdy/trader/pull/8
- Cosmetic fixe on the breadcrumb for correct names
- Update for TraderListener.php file - Multiple languages have some missing language keys