### PR TITLE
Call missing for a language key + proper fix for accentued characters

### DIFF
--- a/Controller/Trader.php
+++ b/Controller/Trader.php
@@ -99,8 +99,8 @@ class Trader
         $feedback_reply_id = $this->request->variable('reply_id', 0);
 
         $rating = $this->request->variable('trader_rating', 0);
-        $short_comment = utf8_normalize_nfc(trim($this->request->variable('short_comment', '', true)));
-        $long_comment = utf8_normalize_nfc(trim($this->request->variable('long_comment', '', true)));
+        $short_comment = trim($this->request->variable('short_comment', '', true));
+        $long_comment = trim($this->request->variable('long_comment', '', true));
 
         if ($feedback_reply_id) {
             $feedback_row = $this->manager->getAllFeedbackInfo($feedback_reply_id);
@@ -145,7 +145,7 @@ class Trader
             trigger_error($this->user->lang('ALREADY_GIVEN_FEEDBACK') . '<br /><br />' . $back_url);
         }
         if ($submit && (strlen($short_comment) < self::MIN_SHORT_LENGTH || strlen($short_comment) > self::MAX_SHORT_LENGTH)) {
-            $err_comments['short'] = '* Required 10-200 Characters';
+            $err_comments['short'] = ($this->user->lang['REQUIRED_CHARACTERS']);
         }
         if ($submit && strlen($long_comment) > self::MAX_LONG_LENGTH) {
             $err_comments['long'] = true;
@@ -215,8 +215,8 @@ class Trader
         $submit = $this->request->is_set_post('submit');
         $to_user_row = $this->getUser($feedback_row['to_user_id']);
         $rating = $this->request->variable('trader_rating', $feedback_row['rating']);
-        $new_short = utf8_normalize_nfc(trim($this->request->variable('short_comment', $feedback_row['short_comment'], true)));
-        $new_long = utf8_normalize_nfc(trim($this->request->variable('long_comment', $feedback_row['long_comment'], true)));
+        $new_short = trim($this->request->variable('short_comment', $feedback_row['short_comment'], true));
+        $new_long = trim($this->request->variable('long_comment', $feedback_row['long_comment'], true));
         $delete_feedback = $this->request->variable('delete_feedback', $feedback_row['is_deleted']);
 
         if ($submit && (strlen($new_short) < self::MIN_SHORT_LENGTH || strlen($new_short) > self::MAX_SHORT_LENGTH)) {


### PR DESCRIPTION
Call missing for a language key for minimum characters in short comment + proper fix for accentued characters:
- update for Trader.php file

RE-Pull request of this: https://github.com/rfdy/trader/pull/15

Recommendation from this: https://github.com/phpbb-extensions/teamsecurity/pull/27#issuecomment-91123052